### PR TITLE
Add dark mode support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1298,6 +1298,51 @@
         }
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.26.tgz",
+      "integrity": "sha512-CcM/fIFwZlRdiWG/25xE/wHbtyUuCtqoCTrr6BsWw7hH072fR++n4L56KPydAr3ANgMJMjT8v83ZFIsDc7kE+A=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.26",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.26.tgz",
+      "integrity": "sha512-3Dfd/v2IztP1TxKOxZiB5+4kaOZK9mNy0KU1vVK7nFlPWz3gzxrCWB+AloQhQUoJ8HhGqbzjliK89Vl7PExGbw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.26"
+      }
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.12.0.tgz",
+      "integrity": "sha512-50uCFzVUki3wfmFmrMNLFhOt8dP6YZ53zwR4dK9FR7Lwq1IVHXnSBb8MtGLe3urLJ2sA+CSu7Pc7s3i6/zLxmA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.26"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.12.0.tgz",
+      "integrity": "sha512-FAvpmylTs0PosHwHrWPQX6/7ODc9M11kCE6AOAujFufDYzqTj2cPHT4yJO7zTEkKdAbbusJzbWpnOboMuyjeQA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.26"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.12.0.tgz",
+      "integrity": "sha512-CnpsWs6GhTs9ekNB3d8rcO5HYqRkXbYKf2YNiAlTWbj5eVlPqsd/XH1F9If8jkcR1aegryAbln/qYeKVZzpM0g==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.26"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.8.tgz",
+      "integrity": "sha512-I5h9YQg/ePA3Br9ISS18fcwOYmzQYDSM1ftH03/8nHkiqIVHtUyQBw482+60dnzvlr82gHt3mGm+nDUp159FCw==",
+      "requires": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13983,6 +13983,11 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "store": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/store/-/store-2.0.12.tgz",
+      "integrity": "sha1-jFNOKguDH3K3X8XxEZhXxE711ZM="
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "redux": "^4.0.4",
     "redux-api-middleware": "^3.0.1",
     "shortstop-handlers": "^1.0.1",
-    "shortstop-regex": "0.0.1"
+    "shortstop-regex": "0.0.1",
+    "store": "^2.0.12"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
   "license": "ISC",
   "dependencies": {
     "@babel/runtime": "^7.5.5",
+    "@fortawesome/fontawesome-svg-core": "^1.2.26",
+    "@fortawesome/free-brands-svg-icons": "^5.12.0",
+    "@fortawesome/free-regular-svg-icons": "^5.12.0",
+    "@fortawesome/free-solid-svg-icons": "^5.12.0",
+    "@fortawesome/react-fontawesome": "^0.1.8",
     "@loadable/component": "^5.12.0",
     "@loadable/server": "^5.12.0",
     "bluebird": "^3.5.5",

--- a/src/components/HomePage/HomePage.css
+++ b/src/components/HomePage/HomePage.css
@@ -20,13 +20,11 @@
 }
 
 .App-header {
-  background-color: var(--backgroundColor);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   font-size: calc(10px + 2vmin);
-  color: white;
 }
 
 .Content {

--- a/src/components/HomePage/__snapshots__/HomePage.test.js.snap
+++ b/src/components/HomePage/__snapshots__/HomePage.test.js.snap
@@ -2,8 +2,31 @@
 
 exports[`HomePage it should render 1`] = `
 <div
-  className="page container-fluid"
+  className="page light-theme container-fluid"
 >
+  <div
+    className="text-right"
+  >
+    Dark Mode
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-toggle-off fa-w-18 fa-2x clickable pad-top-10px"
+      data-icon="toggle-off"
+      data-prefix="fas"
+      focusable="false"
+      onClick={[Function]}
+      role="img"
+      style={Object {}}
+      viewBox="0 0 576 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M384 64H192C85.961 64 0 149.961 0 256s85.961 192 192 192h192c106.039 0 192-85.961 192-192S490.039 64 384 64zM64 256c0-70.741 57.249-128 128-128 70.741 0 128 57.249 128 128 0 70.741-57.249 128-128 128-70.741 0-128-57.249-128-128zm320 128h-48.905c65.217-72.858 65.236-183.12 0-256H384c70.741 0 128 57.249 128 128 0 70.74-57.249 128-128 128z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </div>
   <div
     className="App"
   >

--- a/src/components/NotFound/__snapshots__/NotFound.test.js.snap
+++ b/src/components/NotFound/__snapshots__/NotFound.test.js.snap
@@ -2,8 +2,31 @@
 
 exports[`NotFound it should render 1`] = `
 <div
-  className="page container-fluid"
+  className="page light-theme container-fluid"
 >
+  <div
+    className="text-right"
+  >
+    Dark Mode
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-toggle-off fa-w-18 fa-2x clickable pad-top-10px"
+      data-icon="toggle-off"
+      data-prefix="fas"
+      focusable="false"
+      onClick={[Function]}
+      role="img"
+      style={Object {}}
+      viewBox="0 0 576 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M384 64H192C85.961 64 0 149.961 0 256s85.961 192 192 192h192c106.039 0 192-85.961 192-192S490.039 64 384 64zM64 256c0-70.741 57.249-128 128-128 70.741 0 128 57.249 128 128 0 70.741-57.249 128-128 128-70.741 0-128-57.249-128-128zm320 128h-48.905c65.217-72.858 65.236-183.12 0-256H384c70.741 0 128 57.249 128 128 0 70.74-57.249 128-128 128z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </div>
   <div
     className="container"
   >

--- a/src/components/Page/Page.css
+++ b/src/components/Page/Page.css
@@ -6,9 +6,20 @@ html {
 }
 
 .page {
-  background-color: var(--backgroundColor);
-  color: var(--white);
   font-size: var(--baseFontSize);
   font-family: Helvetica, sans-serif;
   min-height: 100vh;
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.page a:hover {
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.pad-top-10px {
+  padding-top: 10px;
 }

--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -1,17 +1,36 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faToggleOn } from '@fortawesome/free-solid-svg-icons/faToggleOn';
+import { faToggleOff } from '@fortawesome/free-solid-svg-icons/faToggleOff';
 import Container from 'react-bootstrap/Container';
 import DefaultHelmet from '../DefaultHelmet';
 import './Page.css';
+import '../../styles/themes.css';
 
 export default function Page({
   title,
   description,
   children,
 }) {
+  const [hasSwitchedToDarkMode, setHasSwitchedToDarkMode] = useState(false);
+
+  const switchToDarkMode = useCallback(() => {
+    setHasSwitchedToDarkMode(!hasSwitchedToDarkMode);
+  }, [hasSwitchedToDarkMode]);
+
   return (
-    <Container fluid className="page">
+    <Container fluid className={`page ${hasSwitchedToDarkMode ? 'dark-theme' : 'light-theme'}`}>
       <DefaultHelmet title={title} description={description} />
+      <div className="text-right">
+        Dark Mode
+        <FontAwesomeIcon
+          icon={hasSwitchedToDarkMode ? faToggleOn : faToggleOff}
+          size="2x"
+          onClick={switchToDarkMode}
+          className="clickable pad-top-10px"
+        />
+      </div>
       {children}
     </Container>
   );

--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faToggleOn } from '@fortawesome/free-solid-svg-icons/faToggleOn';
@@ -18,6 +18,11 @@ export default function Page({
   const switchToDarkMode = useCallback(() => {
     setHasSwitchedToDarkMode(!hasSwitchedToDarkMode);
   }, [hasSwitchedToDarkMode]);
+
+  // Detect if user prefers dark mode by looking at window object
+  useEffect(() => {
+    setHasSwitchedToDarkMode(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  }, [window.matchMedia]);
 
   return (
     <Container fluid className={`page ${hasSwitchedToDarkMode ? 'dark-theme' : 'light-theme'}`}>

--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import store from 'store';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faToggleOn } from '@fortawesome/free-solid-svg-icons/faToggleOn';
 import { faToggleOff } from '@fortawesome/free-solid-svg-icons/faToggleOff';
@@ -13,16 +14,28 @@ export default function Page({
   description,
   children,
 }) {
-  const [hasSwitchedToDarkMode, setHasSwitchedToDarkMode] = useState(false);
+  const [hasSwitchedToDarkMode, setHasSwitchedToDarkMode] = useState(undefined);
 
   const switchToDarkMode = useCallback(() => {
     setHasSwitchedToDarkMode(!hasSwitchedToDarkMode);
+    store.set('enableDarkMode', !hasSwitchedToDarkMode);
   }, [hasSwitchedToDarkMode]);
 
-  // Detect if user prefers dark mode by looking at window object
+  // Set dark mode initially based on whether user prefers it using os preferences or previously turned it on
   useEffect(() => {
-    setHasSwitchedToDarkMode(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
-  }, [window.matchMedia]);
+    if (hasSwitchedToDarkMode === undefined) {
+      let shouldSetDarkModeInitially = false;
+      const darkModeSetting = store.get('enableDarkMode');
+      if (darkModeSetting === undefined && typeof window !== 'undefined') {
+        shouldSetDarkModeInitially = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      } else {
+        shouldSetDarkModeInitially = darkModeSetting;
+      }
+
+      setHasSwitchedToDarkMode(shouldSetDarkModeInitially);
+      store.set('enableDarkMode', shouldSetDarkModeInitially);
+    }
+  }, [hasSwitchedToDarkMode])
 
   return (
     <Container fluid className={`page ${hasSwitchedToDarkMode ? 'dark-theme' : 'light-theme'}`}>

--- a/src/components/Page/__snapshots__/Page.test.js.snap
+++ b/src/components/Page/__snapshots__/Page.test.js.snap
@@ -2,8 +2,31 @@
 
 exports[`Page it should render 1`] = `
 <div
-  className="page container-fluid"
+  className="page light-theme container-fluid"
 >
+  <div
+    className="text-right"
+  >
+    Dark Mode
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-toggle-off fa-w-18 fa-2x clickable pad-top-10px"
+      data-icon="toggle-off"
+      data-prefix="fas"
+      focusable="false"
+      onClick={[Function]}
+      role="img"
+      style={Object {}}
+      viewBox="0 0 576 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M384 64H192C85.961 64 0 149.961 0 256s85.961 192 192 192h192c106.039 0 192-85.961 192-192S490.039 64 384 64zM64 256c0-70.741 57.249-128 128-128 70.741 0 128 57.249 128 128 0 70.741-57.249 128-128 128-70.741 0-128-57.249-128-128zm320 128h-48.905c65.217-72.858 65.236-183.12 0-256H384c70.741 0 128 57.249 128 128 0 70.74-57.249 128-128 128z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </div>
   <div />
 </div>
 `;

--- a/src/components/ReduxExamplePage/__snapshots__/ReduxExamplePage.test.js.snap
+++ b/src/components/ReduxExamplePage/__snapshots__/ReduxExamplePage.test.js.snap
@@ -2,8 +2,31 @@
 
 exports[`ReduxExamplePage it should render 1`] = `
 <div
-  className="page container-fluid"
+  className="page light-theme container-fluid"
 >
+  <div
+    className="text-right"
+  >
+    Dark Mode
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-toggle-off fa-w-18 fa-2x clickable pad-top-10px"
+      data-icon="toggle-off"
+      data-prefix="fas"
+      focusable="false"
+      onClick={[Function]}
+      role="img"
+      style={Object {}}
+      viewBox="0 0 576 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M384 64H192C85.961 64 0 149.961 0 256s85.961 192 192 192h192c106.039 0 192-85.961 192-192S490.039 64 384 64zM64 256c0-70.741 57.249-128 128-128 70.741 0 128 57.249 128 128 0 70.741-57.249 128-128 128-70.741 0-128-57.249-128-128zm320 128h-48.905c65.217-72.858 65.236-183.12 0-256H384c70.741 0 128 57.249 128 128 0 70.74-57.249 128-128 128z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </div>
   <div
     className="App"
   >

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1,0 +1,35 @@
+@import './variables.css';
+
+.light-theme {
+  background-color: var(--white);
+  color: var(--black);
+}
+
+.light-theme .text {
+  color: var(--black);
+}
+
+.light-theme table.table {
+  color: var(--black);
+}
+
+.light-theme a {
+  color: var(--dark-blue);
+}
+
+.dark-theme {
+  background-color: var(--backgroundColor);
+  color: var(--white);
+}
+
+.dark-theme .text {
+  color: var(--white)
+}
+
+.dark-theme table.table {
+  color: var(--white);
+}
+
+.dark-theme a {
+  color: var(--blue);
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -5,6 +5,7 @@
   --orange: #ed7a00;
   --green: #13ce73;
   --blue: #61dafb;
+  --dark-blue: blue;
   --white: #fff;
   --black: #000;
   --grey: #ededed;


### PR DESCRIPTION
Work to resolve #22.

- Shows dark mode toggle at the right top corner of the page accessible to user on all pages
- Initially loads dark mode if user previously selected it or if user prefers dark mode looking at OS preferences in browser